### PR TITLE
Add config service setup and recorder

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,28 @@ module "firefly-read-only" {
 }
 ```
 
+### Installation with Config Service
+
+```hcl-terraform
+provider "aws" {
+    region     =  "us-east-1"
+}
+
+
+module "firefly-read-only" {
+  source               = "gofireflyio/terraform-firefly-aws-read-only"
+  firefly_access_key   = "YOUR_ACCESS_KEY"
+  firefly_secret_key   = "YOUR_SECRET_KEY"
+  role_external_id     = "YOUR_EXTERNAL_ID"
+  is_prod              = false/true
+  is_event_driven      = true
+  event_driven_regions = ["us-east-1","us-east-2","us-west-1","us-west-2","af-south-1","ap-east-1","ap-south-1","ap-southeast-1","ap-southeast-2","ap-northeast-1","ap-northeast-2","ap-northeast-3","ca-central-1","cn-north-1","cn-northwest-1","eu-central-1","eu-west-1","eu-west-2","eu-west-3","eu-south-1","eu-north-1","me-south-1","sa-east-1"]
+  use_config_service   = true
+  config_service_regions = ["us-east-1","us-east-2","us-west-1","us-west-2","af-south-1","ap-east-1","ap-south-1","ap-southeast-1","ap-southeast-2","ap-northeast-1","ap-northeast-2","ap-northeast-3","ca-central-1","cn-north-1","cn-northwest-1","eu-central-1","eu-west-1","eu-west-2","eu-west-3","eu-south-1","eu-north-1","me-south-1","sa-east-1"]
+  
+}
+```
+
 ### Add Event Driven to Existing Integration
 In order to install event-driven for an existing firefly integration just call the module with:
 ```

--- a/main.tf
+++ b/main.tf
@@ -147,6 +147,7 @@ module "firefly_aws_integration" {
   full_scan_enabled = var.full_scan_enabled
   role_external_id = var.role_external_id
   role_name = var.firefly_role_name
+  firefly_deny_list_policy_name = var.firefly_deny_list_policy_name
   providers          = {
     aws = aws.us_east_1
   }
@@ -620,6 +621,237 @@ module "iac_events_us_west_2" {
   sns_arn = replace(var.iac_events_sns, "us-east-1", "us-west-2")
   region = "us-west-2"
   providers      = {
+    aws = aws.us_west_2
+  }
+}
+
+module "config_service_setup" {
+  depends_on = [module.firefly_aws_integration]
+  count = var.use_config_service ? 1 : 0
+  source = "./modules/config_service_setup"
+  firefly_deny_policy_name = var.firefly_deny_list_policy_name
+  providers = {
+    aws = aws.us_east_1
+  }
+}
+
+module "config_service_recorder_ap_northeast_1" {
+  count = var.use_config_service && contains(var.config_service_regions, "ap-northeast-1") ? 1 : 0
+  source = "./modules/config_service"
+  depends_on = [module.config_service_setup]
+  config_bucket_name = module.config_service_setup[0].delivery_bucket_name
+  config_service_role_arn = module.config_service_setup[0].config_service_role_arn
+  region = "ap-northeast-1"
+  config_service_regions = var.config_service_regions
+  providers = {
+    aws = aws.ap_northeast_1
+  }
+}
+
+module "config_service_recorder_ap_northeast_2" {
+  count = var.use_config_service && contains(var.config_service_regions, "ap-northeast-2") ? 1 : 0
+  source = "./modules/config_service"
+  depends_on = [module.config_service_setup]
+  config_bucket_name = module.config_service_setup[0].delivery_bucket_name
+  config_service_role_arn = module.config_service_setup[0].config_service_role_arn
+  region = "ap-northeast-2"
+  config_service_regions = var.config_service_regions
+  providers = {
+    aws = aws.ap_northeast_2
+  }
+}
+
+module "config_service_recorder_ap_northeast_3" {
+  count = var.use_config_service && contains(var.config_service_regions, "ap-northeast-3") ? 1 : 0
+  source = "./modules/config_service"
+  depends_on = [module.config_service_setup]
+  config_bucket_name = module.config_service_setup[0].delivery_bucket_name
+  config_service_role_arn = module.config_service_setup[0].config_service_role_arn
+  region = "ap-northeast-3"
+  config_service_regions = var.config_service_regions
+  providers = {
+    aws = aws.ap_northeast_3
+  }
+}
+
+module "config_service_recorder_ap_south_1" {
+  count = var.use_config_service && contains(var.config_service_regions, "ap-south-1") ? 1 : 0
+  source = "./modules/config_service"
+  depends_on = [module.config_service_setup]
+  config_bucket_name = module.config_service_setup[0].delivery_bucket_name
+  config_service_role_arn = module.config_service_setup[0].config_service_role_arn
+  region = "ap-south-1"
+  config_service_regions = var.config_service_regions
+  providers = {
+    aws = aws.ap_south_1
+  }
+}
+
+module "config_service_recorder_ap_southeast_1" {
+  count = var.use_config_service && contains(var.config_service_regions, "ap-southeast-1") ? 1 : 0
+  source = "./modules/config_service"
+  depends_on = [module.config_service_setup]
+  config_bucket_name = module.config_service_setup[0].delivery_bucket_name
+  config_service_role_arn = module.config_service_setup[0].config_service_role_arn
+  region = "ap-southeast-1"
+  config_service_regions = var.config_service_regions
+  providers = {
+    aws = aws.ap_southeast_1
+  }
+}
+
+module "config_service_recorder_ap_southeast_2" {
+  count = var.use_config_service && contains(var.config_service_regions, "ap-southeast-2") ? 1 : 0
+  source = "./modules/config_service"
+  depends_on = [module.config_service_setup]
+  config_bucket_name = module.config_service_setup[0].delivery_bucket_name
+  config_service_role_arn = module.config_service_setup[0].config_service_role_arn
+  region = "ap-southeast-2"
+  config_service_regions = var.config_service_regions
+  providers = {
+    aws = aws.ap_southeast_2
+  }
+}
+
+module "config_service_recorder_ca_central_1" {
+  count = var.use_config_service && contains(var.config_service_regions, "ca-central-1") ? 1 : 0
+  source = "./modules/config_service"
+  depends_on = [module.config_service_setup]
+  config_bucket_name = module.config_service_setup[0].delivery_bucket_name
+  config_service_role_arn = module.config_service_setup[0].config_service_role_arn
+  region = "ca-central-1"
+  config_service_regions = var.config_service_regions
+  providers = {
+    aws = aws.ca_central_1
+  }
+}
+
+module "config_service_recorder_eu_central_1" {
+  count = var.use_config_service && contains(var.config_service_regions, "eu-central-1") ? 1 : 0
+  source = "./modules/config_service"
+  depends_on = [module.config_service_setup]
+  config_bucket_name = module.config_service_setup[0].delivery_bucket_name
+  config_service_role_arn = module.config_service_setup[0].config_service_role_arn
+  region = "eu-central-1"
+  config_service_regions = var.config_service_regions
+  providers = {
+    aws = aws.eu_central_1
+  }
+}
+
+module "config_service_recorder_eu_north_1" {
+  count = var.use_config_service && contains(var.config_service_regions, "eu-north-1") ? 1 : 0
+  source = "./modules/config_service"
+  depends_on = [module.config_service_setup]
+  config_bucket_name = module.config_service_setup[0].delivery_bucket_name
+  config_service_role_arn = module.config_service_setup[0].config_service_role_arn
+  region = "eu-north-1"
+  config_service_regions = var.config_service_regions
+  providers = {
+    aws = aws.eu_north_1
+  }
+}
+
+module "config_service_recorder_eu_west_1" {
+  count = var.use_config_service && contains(var.config_service_regions, "eu-west-1") ? 1 : 0
+  source = "./modules/config_service"
+  depends_on = [module.config_service_setup]
+  config_bucket_name = module.config_service_setup[0].delivery_bucket_name
+  config_service_role_arn = module.config_service_setup[0].config_service_role_arn
+  region = "eu-west-1"
+  config_service_regions = var.config_service_regions
+  providers = {
+    aws = aws.eu_west_1
+  }
+}
+
+module "config_service_recorder_eu_west_2" {
+  count = var.use_config_service && contains(var.config_service_regions, "eu-west-2") ? 1 : 0
+  source = "./modules/config_service"
+  depends_on = [module.config_service_setup]
+  config_bucket_name = module.config_service_setup[0].delivery_bucket_name
+  config_service_role_arn = module.config_service_setup[0].config_service_role_arn
+  region = "eu-west-2"
+  config_service_regions = var.config_service_regions
+  providers = {
+    aws = aws.eu_west_2
+  }
+}
+
+module "config_service_recorder_eu_west_3" {
+  count = var.use_config_service && contains(var.config_service_regions, "eu-west-3") ? 1 : 0
+  source = "./modules/config_service"
+  depends_on = [module.config_service_setup]
+  config_bucket_name = module.config_service_setup[0].delivery_bucket_name
+  config_service_role_arn = module.config_service_setup[0].config_service_role_arn
+  region = "eu-west-3"
+  config_service_regions = var.config_service_regions
+  providers = {
+    aws = aws.eu_west_3
+  }
+}
+
+module "config_service_recorder_sa_east_1" {
+  count = var.use_config_service && contains(var.config_service_regions, "sa-east-1") ? 1 : 0
+  source = "./modules/config_service"
+  depends_on = [module.config_service_setup]
+  config_bucket_name = module.config_service_setup[0].delivery_bucket_name
+  config_service_role_arn = module.config_service_setup[0].config_service_role_arn
+  region = "sa-east-1"
+  config_service_regions = var.config_service_regions
+  providers = {
+    aws = aws.sa_east_1
+  }
+}
+
+module "config_service_recorder_us_east_1" {
+  count = var.use_config_service && contains(var.config_service_regions, "us-east-1") ? 1 : 0
+  source = "./modules/config_service"
+  depends_on = [module.config_service_setup]
+  config_bucket_name = module.config_service_setup[0].delivery_bucket_name
+  config_service_role_arn = module.config_service_setup[0].config_service_role_arn
+  region = "us-east-1"
+  config_service_regions = var.config_service_regions
+  providers = {
+    aws = aws.us_east_1
+  }
+}
+
+module "config_service_recorder_us_east_2" {
+  count = var.use_config_service && contains(var.config_service_regions, "us-east-2") ? 1 : 0
+  source = "./modules/config_service"
+  depends_on = [module.config_service_setup]
+  config_bucket_name = module.config_service_setup[0].delivery_bucket_name
+  config_service_role_arn = module.config_service_setup[0].config_service_role_arn
+  region = "us-east-2"
+  config_service_regions = var.config_service_regions
+  providers = {
+    aws = aws.us_east_2
+  }
+}
+
+module "config_service_recorder_us_west_1" {
+  count = var.use_config_service && contains(var.config_service_regions, "us-west-1") ? 1 : 0
+  source = "./modules/config_service"
+  depends_on = [module.config_service_setup]
+  config_bucket_name = module.config_service_setup[0].delivery_bucket_name
+  config_service_role_arn = module.config_service_setup[0].config_service_role_arn
+  region = "us-west-1"
+  config_service_regions = var.config_service_regions
+  providers = {
+    aws = aws.us_west_1
+  }
+}
+
+module "config_service_recorder_us_west_2" {
+  count = var.use_config_service && contains(var.config_service_regions, "us-west-2") ? 1 : 0
+  source = "./modules/config_service"
+  depends_on = [module.config_service_setup]
+  config_bucket_name = module.config_service_setup[0].delivery_bucket_name
+  config_service_role_arn = module.config_service_setup[0].config_service_role_arn
+  region = "us-west-2"
+  config_service_regions = var.config_service_regions
+  providers = {
     aws = aws.us_west_2
   }
 }

--- a/modules/config_service/locals.tf
+++ b/modules/config_service/locals.tf
@@ -1,0 +1,3 @@
+locals {
+  global_services_region = length(var.config_service_regions) > 0 ?  var.config_service_regions[0] : ""
+}

--- a/modules/config_service/main.tf
+++ b/modules/config_service/main.tf
@@ -1,0 +1,20 @@
+resource "aws_config_delivery_channel" "s3_delivery_channel" {
+  name           = "s3-delivery-channel"
+  s3_bucket_name = var.config_bucket_name
+  depends_on     = [aws_config_configuration_recorder.config_configuration_recorder]
+}
+
+resource "aws_config_configuration_recorder" "config_configuration_recorder" {
+  name     = "recorder"
+  role_arn = var.config_service_role_arn
+  recording_group {
+    all_supported = true
+    include_global_resource_types = var.region == local.global_services_region ? true : false
+  }
+}
+
+resource "aws_config_configuration_recorder_status" "config_status" {
+  name       = aws_config_configuration_recorder.config_configuration_recorder.name
+  is_enabled = true
+  depends_on = [aws_config_delivery_channel.s3_delivery_channel]
+}

--- a/modules/config_service/terraform.tf
+++ b/modules/config_service/terraform.tf
@@ -1,0 +1,8 @@
+terraform {
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "3.74.0"
+    }
+  }
+}

--- a/modules/config_service/vars.tf
+++ b/modules/config_service/vars.tf
@@ -1,0 +1,17 @@
+variable "config_service_role_arn" {
+  type = string
+}
+
+variable "config_bucket_name" {
+  type = string
+}
+
+variable "region" {
+  type = string
+}
+
+variable "config_service_regions" {
+  type        = list(string)
+  description = "The list of regions to activate config service recorder"
+  default     = []
+}

--- a/modules/config_service_setup/main.tf
+++ b/modules/config_service_setup/main.tf
@@ -1,0 +1,66 @@
+data "aws_caller_identity" "current" {}
+
+resource "aws_iam_policy" "config_service_management_policy" {
+  name        = "ConfigServiceManagementPolicy"
+  path        = "/"
+  description = "this policy allows the config service to use it's s3 bucket to store the service's data"
+  policy      = jsonencode({
+    "Version" : "2012-10-17",
+    "Statement" : [
+      {
+        "Action" : [
+          "s3:*"
+        ],
+        "Effect" : "Allow",
+        "Resource" : [
+          "${aws_s3_bucket.config_bucket.arn}",
+          "${aws_s3_bucket.config_bucket.arn}/*"
+        ]
+      },
+      {
+        "Effect" : "Allow",
+        "Action" : [
+          "logs:CreateLogStream",
+          "logs:CreateLogGroup"
+        ],
+        "Resource" : "arn:aws:logs:*:*:log-group:/aws/config/*"
+      },
+      {
+        "Effect" : "Allow",
+        "Action" : "logs:PutLogEvents",
+        "Resource" : "arn:aws:logs:*:*:log-group:/aws/config/*:log-stream:config-rule-evaluation/*"
+      }
+    ]
+  })
+}
+
+resource "aws_iam_role" "aws_config_role" {
+  name                = "aws-config-role"
+  description         = "this role allows the config service a read only permissions to the cloud configuration, and permissions to it's s3 bucket"
+  assume_role_policy  = <<POLICY
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Action": "sts:AssumeRole",
+      "Principal": {
+        "Service": "config.amazonaws.com"
+      },
+      "Effect": "Allow",
+      "Sid": ""
+    }
+  ]
+}
+POLICY
+  managed_policy_arns = [
+    "arn:aws:iam::${data.aws_caller_identity.current.account_id}:policy/${var.firefly_deny_policy_name}",
+    aws_iam_policy.config_service_management_policy.arn,
+    "arn:aws:iam::aws:policy/SecurityAudit",
+    "arn:aws:iam::aws:policy/ReadOnlyAccess",
+  ]
+}
+
+resource "aws_s3_bucket" "config_bucket" {
+  bucket        = "aws-config-service-bucket-${data.aws_caller_identity.current.account_id}"
+  force_destroy = true
+}

--- a/modules/config_service_setup/output.tf
+++ b/modules/config_service_setup/output.tf
@@ -1,0 +1,7 @@
+output "delivery_bucket_name" {
+  value = aws_s3_bucket.config_bucket.bucket
+}
+
+output "config_service_role_arn" {
+  value = aws_iam_role.aws_config_role.arn
+}

--- a/modules/config_service_setup/terraform.tf
+++ b/modules/config_service_setup/terraform.tf
@@ -1,0 +1,8 @@
+terraform {
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "3.74.0"
+    }
+  }
+}

--- a/modules/config_service_setup/vars.tf
+++ b/modules/config_service_setup/vars.tf
@@ -1,0 +1,3 @@
+variable "firefly_deny_policy_name" {
+  type = string
+}

--- a/modules/firefly_aws_integration/iam.tf
+++ b/modules/firefly_aws_integration/iam.tf
@@ -5,7 +5,7 @@ locals {
 }
 
 resource "aws_iam_policy" "firefly_readonly_policy_deny_list" {
-  name        = "FireflyReadonlyPolicyDenyList"
+  name        = var.firefly_deny_list_policy_name
   path        = "/"
   description = "Read only permission for the cloud configuration - Deny List"
 

--- a/modules/firefly_aws_integration/vars.tf
+++ b/modules/firefly_aws_integration/vars.tf
@@ -50,6 +50,11 @@ variable "role_name"{
   description = "The name for the Firefly role generated"
 }
 
+variable "firefly_deny_list_policy_name"{
+  type        = string
+  description = "The name for the Firefly deny policy generated"
+}
+
 variable "use_config_service" {
   type = bool
   default = true

--- a/variables.tf
+++ b/variables.tf
@@ -41,6 +41,12 @@ variable "firefly_role_name" {
   type    = string
 }
 
+variable "firefly_deny_list_policy_name" {
+  type        = string
+  description = "The name for the Firefly deny policy generated"
+  default     = "FireflyReadonlyPolicyDenyList"
+}
+
 variable full_scan_enabled {
   type        = bool
   default     = true
@@ -103,4 +109,17 @@ variable "buckets_by_region" {
 variable "iac_events_sns" {
   default     = "arn:aws:sns:us-east-1:094724549126:firefly-iac-states-update-topic"
   description = "Firefly sns which receives s3 object events notification"
+}
+
+variable "use_config_service" {
+  type        = bool
+  default     = false
+  description = "Allow Firefly to read the config service s3 objects"
+}
+
+
+variable "config_service_regions" {
+  type        = list(string)
+  description = "The list of regions to install firefly event driven in"
+  default     = []
 }


### PR DESCRIPTION
Add config service module which manages firefly's access to the AWS config service. The module activates the config service recorder in the selected regions. In addition, the module creates an S3 bucket as a delivery channel and the IAM role for the config service